### PR TITLE
Make renderEmbedSnap a static function

### DIFF
--- a/EmbedSnap.php
+++ b/EmbedSnap.php
@@ -26,7 +26,7 @@ class EmbedSnap{
 	    return true;
 	}
 	
-	function renderEmbedSnap ($input, $argv, $parser) { // Function to render the iframes for the <snap> tags
+	static function renderEmbedSnap ($input, $argv, $parser) { // Function to render the iframes for the <snap> tags
 		$project = '';
 		$user = '';
 		$width = $width_max = 930;


### PR DESCRIPTION
Otherwise you get:

PHP Deprecated:  Non-static method EmbedSnap::renderEmbedSnap() should not be called statically in /srv/mediawiki/w/includes/parser/Parser.php on line 4798